### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/Effect/AVar.purs
+++ b/src/Effect/AVar.purs
@@ -28,6 +28,8 @@ type AVarCallback a = (Either Error a → Effect Unit)
 
 foreign import data AVar ∷ Type → Type
 
+type role AVar representational
+
 data AVarStatus a
   = Killed Error
   | Filled a


### PR DESCRIPTION
This allows terms of type `AVar a` to be coerced to type `AVar b` when `Coercible a b` holds, hence allowing the zero cost `coerce` instead of `map wrap` and `map unwrap` to introduce and eliminate newtypes under asynchronous variables for instance.