### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -25,9 +27,9 @@ jobs:
             output
 
       - name: Set up Node toolchain
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v2
@@ -49,3 +51,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 !.eslintrc.json
 
 output

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#27 by @thomashoneyman)
 
 ## [v4.0.0](https://github.com/purescript-contrib/purescript-avar/releases/tag/v4.0.0) - 2021-02-26
 

--- a/src/Effect/AVar.purs
+++ b/src/Effect/AVar.purs
@@ -24,9 +24,9 @@ import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (Error)
 
-type AVarCallback a = (Either Error a → Effect Unit)
+type AVarCallback a = (Either Error a -> Effect Unit)
 
-foreign import data AVar ∷ Type → Type
+foreign import data AVar :: Type -> Type
 
 type role AVar representational
 
@@ -36,92 +36,92 @@ data AVarStatus a
   | Empty
 
 -- | Creates a new empty AVar.
-foreign import empty ∷ ∀ a. Effect (AVar a)
+foreign import empty :: forall a. Effect (AVar a)
 
 -- | Creates a fresh AVar with an initial value.
-new ∷ ∀ a. a → Effect (AVar a)
+new :: forall a. a -> Effect (AVar a)
 new = _newVar
 
 -- | Kills the AVar with an exception. All pending and future actions will
 -- | resolve immediately with the provided exception.
-kill ∷ ∀ a. Error → AVar a → Effect Unit
+kill :: forall a. Error -> AVar a -> Effect Unit
 kill err avar = Fn.runFn3 _killVar ffiUtil err avar
 
 -- | Sets the value of the AVar. If the AVar is already filled, it will be
 -- | queued until the value is emptied. Multiple puts will resolve in order as
 -- | the AVar becomes available. Returns an effect which will remove the
 -- | callback from the pending queue.
-put ∷ ∀ a. a → AVar a → AVarCallback Unit → Effect (Effect Unit)
+put :: forall a. a -> AVar a -> AVarCallback Unit -> Effect (Effect Unit)
 put value avar cb = Fn.runFn4 _putVar ffiUtil value avar cb
 
 -- | Attempts to synchronously fill an AVar. If the AVar is already filled,
 -- | this will do nothing. Returns true or false depending on if it succeeded.
-tryPut ∷ ∀ a. a → AVar a → Effect Boolean
+tryPut :: forall a. a -> AVar a -> Effect Boolean
 tryPut value avar = Fn.runFn3 _tryPutVar ffiUtil value avar
 
 -- | Takes the AVar value, leaving it empty. If the AVar is already empty,
 -- | the callback will be queued until the AVar is filled. Multiple takes will
 -- | resolve in order as the AVar fills. Returns an effect which will remove
 -- | the callback from the pending queue.
-take ∷ ∀ a. AVar a → AVarCallback a → Effect (Effect Unit)
+take :: forall a. AVar a -> AVarCallback a -> Effect (Effect Unit)
 take avar cb = Fn.runFn3 _takeVar ffiUtil avar cb
 
 -- | Attempts to synchronously take an AVar value, leaving it empty. If the
 -- | AVar is empty, this will return `Nothing`.
-tryTake ∷ ∀ a. AVar a → Effect (Maybe a)
+tryTake :: forall a. AVar a -> Effect (Maybe a)
 tryTake avar = Fn.runFn2 _tryTakeVar ffiUtil avar
 
 -- | Reads the AVar value. Unlike `take`, this will not leave the AVar empty.
 -- | If the AVar is empty, this will queue until it is filled. Multiple reads
 -- | will resolve at the same time, as soon as possible.
-read ∷ ∀ a. AVar a → AVarCallback a → Effect (Effect Unit)
+read :: forall a. AVar a -> AVarCallback a -> Effect (Effect Unit)
 read avar cb = Fn.runFn3 _readVar ffiUtil avar cb
 
 -- | Attempts to synchronously read an AVar. If the AVar is empty, this will
 -- | return `Nothing`.
-tryRead ∷ ∀ a. AVar a → Effect (Maybe a)
+tryRead :: forall a. AVar a -> Effect (Maybe a)
 tryRead avar = Fn.runFn2 _tryReadVar ffiUtil avar
 
 -- | Synchronously checks the status of an AVar.
-status ∷ ∀ a. AVar a → Effect (AVarStatus a)
+status :: forall a. AVar a -> Effect (AVarStatus a)
 status avar = Fn.runFn2 _status ffiUtil avar
 
-isEmpty ∷ ∀ a. AVarStatus a → Boolean
+isEmpty :: forall a. AVarStatus a -> Boolean
 isEmpty = case _ of
-  Empty → true
-  _ → false
+  Empty -> true
+  _ -> false
 
-isFilled ∷ ∀ a. AVarStatus a → Boolean
+isFilled :: forall a. AVarStatus a -> Boolean
 isFilled = case _ of
-  Filled _ → true
-  _ → false
+  Filled _ -> true
+  _ -> false
 
-isKilled ∷ ∀ a. AVarStatus a → Boolean
+isKilled :: forall a. AVarStatus a -> Boolean
 isKilled = case _ of
-  Killed _ → true
-  _ → false
+  Killed _ -> true
+  _ -> false
 
-foreign import _newVar ∷ ∀ a. a → Effect (AVar a)
-foreign import _killVar ∷ ∀ a. Fn.Fn3 FFIUtil Error (AVar a) (Effect Unit)
-foreign import _putVar ∷ ∀ a. Fn.Fn4 FFIUtil a (AVar a) (AVarCallback Unit) (Effect (Effect Unit))
-foreign import _tryPutVar ∷ ∀ a. Fn.Fn3 FFIUtil a (AVar a) (Effect Boolean)
-foreign import _takeVar ∷ ∀ a. Fn.Fn3 FFIUtil (AVar a) (AVarCallback a) (Effect (Effect Unit))
-foreign import _tryTakeVar ∷ ∀ a. Fn.Fn2 FFIUtil (AVar a) (Effect (Maybe a))
-foreign import _readVar ∷ ∀ a. Fn.Fn3 FFIUtil (AVar a) (AVarCallback a) (Effect (Effect Unit))
-foreign import _tryReadVar ∷ ∀ a. Fn.Fn2 FFIUtil (AVar a) (Effect (Maybe a))
-foreign import _status ∷ ∀ a. Fn.Fn2 FFIUtil (AVar a) (Effect (AVarStatus a))
+foreign import _newVar :: forall a. a -> Effect (AVar a)
+foreign import _killVar :: forall a. Fn.Fn3 FFIUtil Error (AVar a) (Effect Unit)
+foreign import _putVar :: forall a. Fn.Fn4 FFIUtil a (AVar a) (AVarCallback Unit) (Effect (Effect Unit))
+foreign import _tryPutVar :: forall a. Fn.Fn3 FFIUtil a (AVar a) (Effect Boolean)
+foreign import _takeVar :: forall a. Fn.Fn3 FFIUtil (AVar a) (AVarCallback a) (Effect (Effect Unit))
+foreign import _tryTakeVar :: forall a. Fn.Fn2 FFIUtil (AVar a) (Effect (Maybe a))
+foreign import _readVar :: forall a. Fn.Fn3 FFIUtil (AVar a) (AVarCallback a) (Effect (Effect Unit))
+foreign import _tryReadVar :: forall a. Fn.Fn2 FFIUtil (AVar a) (Effect (Maybe a))
+foreign import _status :: forall a. Fn.Fn2 FFIUtil (AVar a) (Effect (AVarStatus a))
 
 type FFIUtil =
-  { left ∷ ∀ a b. a → Either a b
-  , right ∷ ∀ a b. b → Either a b
-  , nothing ∷ ∀ a. Maybe a
-  , just ∷ ∀ a. a → Maybe a
-  , killed ∷ ∀ a. Error → AVarStatus a
-  , filled ∷ ∀ a. a → AVarStatus a
-  , empty ∷ ∀ a. AVarStatus a
+  { left :: forall a b. a -> Either a b
+  , right :: forall a b. b -> Either a b
+  , nothing :: forall a. Maybe a
+  , just :: forall a. a -> Maybe a
+  , killed :: forall a. Error -> AVarStatus a
+  , filled :: forall a. a -> AVarStatus a
+  , empty :: forall a. AVarStatus a
   }
 
-ffiUtil ∷ FFIUtil
+ffiUtil :: FFIUtil
 ffiUtil =
   { left: Left
   , right: Right

--- a/src/Effect/Aff/AVar.purs
+++ b/src/Effect/Aff/AVar.purs
@@ -21,57 +21,57 @@ import Effect.Class (liftEffect)
 import Effect.Exception (Error)
 
 -- | Creates a fresh AVar with an initial value.
-new ∷ ∀ a. a → Aff (AVar a)
+new :: forall a. a -> Aff (AVar a)
 new = liftEffect <<< AVar.new
 
 -- | Creates a fresh AVar.
-empty ∷ ∀ a. Aff (AVar a)
+empty :: forall a. Aff (AVar a)
 empty = liftEffect AVar.empty
 
 -- | Synchronously checks the status of an AVar.
-status ∷ ∀ a. AVar a → Aff (AVar.AVarStatus a)
+status :: forall a. AVar a -> Aff (AVar.AVarStatus a)
 status = liftEffect <<< AVar.status
 
 -- | Takes the AVar value, leaving it empty. If the AVar is already empty,
 -- | the callback will be queued until the AVar is filled. Multiple takes will
 -- | resolve in order as the AVar fills.
-take ∷ ∀ a. AVar a → Aff a
-take avar = makeAff \k → do
-  c ← AVar.take avar k
+take :: forall a. AVar a -> Aff a
+take avar = makeAff \k -> do
+  c <- AVar.take avar k
   pure (effectCanceler c)
 
 -- | Attempts to synchronously take an AVar value, leaving it empty. If the
 -- | AVar is empty, this will return `Nothing`.
-tryTake ∷ ∀ a. AVar a → Aff (Maybe a)
+tryTake :: forall a. AVar a -> Aff (Maybe a)
 tryTake = liftEffect <<< AVar.tryTake
 
 -- | Sets the value of the AVar. If the AVar is already filled, it will be
 -- | queued until the value is emptied. Multiple puts will resolve in order as
 -- | the AVar becomes available.
-put ∷ ∀ a. a → AVar a → Aff Unit
-put value avar = makeAff \k → do
-  c ← AVar.put value avar k
+put :: forall a. a -> AVar a -> Aff Unit
+put value avar = makeAff \k -> do
+  c <- AVar.put value avar k
   pure (effectCanceler c)
 
 -- | Attempts to synchronously fill an AVar. If the AVar is already filled,
 -- | this will do nothing. Returns true or false depending on if it succeeded.
-tryPut ∷ ∀ a. a → AVar a → Aff Boolean
+tryPut :: forall a. a -> AVar a -> Aff Boolean
 tryPut value = liftEffect <<< AVar.tryPut value
 
 -- | Reads the AVar value. Unlike `take`, this will not leave the AVar empty.
 -- | If the AVar is empty, this will queue until it is filled. Multiple reads
 -- | will resolve at the same time, as soon as possible.
-read ∷ ∀ a. AVar a → Aff a
-read avar = makeAff \k → do
-  c ← AVar.read avar k
+read :: forall a. AVar a -> Aff a
+read avar = makeAff \k -> do
+  c <- AVar.read avar k
   pure (effectCanceler c)
 
 -- | Attempts to synchronously read an AVar. If the AVar is empty, this will
 -- | return `Nothing`.
-tryRead ∷ ∀ a. AVar a → Aff (Maybe a)
+tryRead :: forall a. AVar a -> Aff (Maybe a)
 tryRead = liftEffect <<< AVar.tryRead
 
 -- | Kills the AVar with an exception. All pending and future actions will
 -- | resolve immediately with the provided exception.
-kill ∷ ∀ a. Error → AVar a → Aff Unit
+kill :: forall a. Error -> AVar a -> Aff Unit
 kill error = liftEffect <<< AVar.kill error

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -11,185 +11,185 @@ import Data.Foldable (traverse_)
 import Data.Maybe (Maybe(..))
 import Test.Assert (assert')
 
-test ∷ String → Effect Boolean → Effect Unit
-test s k = k >>= \r → assert' s r *> log ("[OK] " <> s)
+test :: String -> Effect Boolean -> Effect Unit
+test s k = k >>= \r -> assert' s r *> log ("[OK] " <> s)
 
-test_tryRead_full ∷ Effect Unit
+test_tryRead_full :: Effect Unit
 test_tryRead_full = test "tryRead/full" do
-  var ← AVar.new "foo"
-  val1 ← AVar.tryRead var
-  val2 ← AVar.tryRead var
+  var <- AVar.new "foo"
+  val1 <- AVar.tryRead var
+  val2 <- AVar.tryRead var
   pure (val1 == Just "foo" && val2 == Just "foo")
 
-test_tryRead_empty ∷ Effect Unit
+test_tryRead_empty :: Effect Unit
 test_tryRead_empty = test "tryRead/empty" do
-  var ← AVar.empty
-  val1 ∷ Maybe Unit ← AVar.tryRead var
+  var <- AVar.empty
+  val1 :: Maybe Unit <- AVar.tryRead var
   pure (val1 == Nothing)
 
-test_tryPut_full ∷ Effect Unit
+test_tryPut_full :: Effect Unit
 test_tryPut_full = test "tryPut/full" do
-  var ← AVar.new "foo"
-  res ← AVar.tryPut "bar" var
+  var <- AVar.new "foo"
+  res <- AVar.tryPut "bar" var
   pure (not res)
 
-test_tryPut_empty ∷ Effect Unit
+test_tryPut_empty :: Effect Unit
 test_tryPut_empty = test "tryPut/empty" do
-  var ← AVar.empty
-  res ← AVar.tryPut "foo" var
-  val ← AVar.tryRead var
+  var <- AVar.empty
+  res <- AVar.tryPut "foo" var
+  val <- AVar.tryRead var
   pure (res && val == Just "foo")
 
-test_tryTake_full ∷ Effect Unit
+test_tryTake_full :: Effect Unit
 test_tryTake_full = test "tryTake/full" do
-  var ← AVar.new "foo"
-  res1 ← AVar.tryTake var
-  res2 ← AVar.tryTake var
+  var <- AVar.new "foo"
+  res1 <- AVar.tryTake var
+  res2 <- AVar.tryTake var
   pure (res1 == Just "foo" && res2 == Nothing)
 
-test_tryTake_empty ∷ Effect Unit
+test_tryTake_empty :: Effect Unit
 test_tryTake_empty = test "tryTake/empty" do
-  var  ← AVar.empty
-  res1 ← AVar.tryTake var
-  res2 ← AVar.tryPut "foo" var
-  res3 ← AVar.tryTake var
+  var <- AVar.empty
+  res1 <- AVar.tryTake var
+  res2 <- AVar.tryPut "foo" var
+  res3 <- AVar.tryTake var
   pure (res1 == Nothing && res2 && res3 == Just "foo")
 
-test_put_take ∷ Effect Unit
+test_put_take :: Effect Unit
 test_put_take = test "put/take" do
-  ref ← Ref.new ""
-  var ← AVar.empty
-  _ ← AVar.put "foo" var $ traverse_ \_ →
+  ref <- Ref.new ""
+  var <- AVar.empty
+  _ <- AVar.put "foo" var $ traverse_ \_ ->
     void $ Ref.modify (_ <> "bar") ref
-  _ ← AVar.take var $ traverse_ \val →
+  _ <- AVar.take var $ traverse_ \val ->
     void $ Ref.modify (_ <> val) ref
   eq "barfoo" <$> Ref.read ref
 
-test_put_read_take ∷ Effect Unit
+test_put_read_take :: Effect Unit
 test_put_read_take = test "put/read/take" do
-  ref ← Ref.new ""
-  var ← AVar.empty
-  _ ← AVar.put "foo" var $ traverse_ \_ →
+  ref <- Ref.new ""
+  var <- AVar.empty
+  _ <- AVar.put "foo" var $ traverse_ \_ ->
     void $ Ref.modify (_ <> "bar") ref
-  _ ← AVar.read var $ traverse_ \val →
+  _ <- AVar.read var $ traverse_ \val ->
     void $ Ref.modify (_ <> val <> "baz") ref
-  _ ← AVar.take var $ traverse_ \val →
+  _ <- AVar.take var $ traverse_ \val ->
     void $ Ref.modify (_ <> val) ref
   eq "barfoobazfoo" <$> Ref.read ref
 
-test_take_put ∷ Effect Unit
+test_take_put :: Effect Unit
 test_take_put = test "take/put" do
-  ref ← Ref.new ""
-  var ← AVar.empty
-  _ ← AVar.take var $ traverse_ \val →
+  ref <- Ref.new ""
+  var <- AVar.empty
+  _ <- AVar.take var $ traverse_ \val ->
     void $ Ref.modify (_ <> val) ref
-  _ ← AVar.put "foo" var $ traverse_ \_ →
+  _ <- AVar.put "foo" var $ traverse_ \_ ->
     void $ Ref.modify (_ <> "bar") ref
   eq "foobar" <$> Ref.read ref
 
-test_take_read_put ∷ Effect Unit
+test_take_read_put :: Effect Unit
 test_take_read_put = test "take/read/put" do
-  ref ← Ref.new ""
-  var ← AVar.empty
-  _ ← AVar.take var $ traverse_ \val →
+  ref <- Ref.new ""
+  var <- AVar.empty
+  _ <- AVar.take var $ traverse_ \val ->
     void $ Ref.modify (_ <> val) ref
-  _ ← AVar.read var $ traverse_ \val →
+  _ <- AVar.read var $ traverse_ \val ->
     void $ Ref.modify (_ <> val <> "baz") ref
-  _ ← AVar.put "foo" var $ traverse_ \_ →
+  _ <- AVar.put "foo" var $ traverse_ \_ ->
     void $ Ref.modify (_ <> "bar") ref
   eq "foobazfoobar" <$> Ref.read ref
 
-test_read_put_take ∷ Effect Unit
+test_read_put_take :: Effect Unit
 test_read_put_take = test "read/put/take" do
-  ref ← Ref.new ""
-  var ← AVar.empty
-  _ ← AVar.read var $ traverse_ \val →
+  ref <- Ref.new ""
+  var <- AVar.empty
+  _ <- AVar.read var $ traverse_ \val ->
     void $ Ref.modify (_ <> val <> "baz") ref
-  _ ← AVar.put "foo" var $ traverse_ \_ →
+  _ <- AVar.put "foo" var $ traverse_ \_ ->
     void $ Ref.modify (_ <> "bar") ref
-  _ ← AVar.take var $ traverse_ \val → do
+  _ <- AVar.take var $ traverse_ \val -> do
     void $ Ref.modify (_ <> val) ref
   eq "foobazbarfoo" <$> Ref.read ref
 
-test_read_take_put ∷ Effect Unit
+test_read_take_put :: Effect Unit
 test_read_take_put = test "read/take/put" do
-  ref ← Ref.new ""
-  var ← AVar.empty
-  _ ← AVar.read var $ traverse_ \val → do
+  ref <- Ref.new ""
+  var <- AVar.empty
+  _ <- AVar.read var $ traverse_ \val -> do
     void $ Ref.modify (_ <> val <> "baz") ref
-    void $ AVar.take var $ traverse_ \val' →
+    void $ AVar.take var $ traverse_ \val' ->
       void $ Ref.modify (_ <> val') ref
-  _ ← AVar.put "foo" var $ traverse_ \_ →
+  _ <- AVar.put "foo" var $ traverse_ \_ ->
     void $ Ref.modify (_ <> "bar") ref
   eq "foobazbarfoo" <$> Ref.read ref
 
-test_kill_full ∷ Effect Unit
+test_kill_full :: Effect Unit
 test_kill_full = test "kill/full" do
-  ref ← Ref.new ""
-  var ← AVar.empty
-  _ ← AVar.put "foo" var $ traverse_ \_ →
+  ref <- Ref.new ""
+  var <- AVar.empty
+  _ <- AVar.put "foo" var $ traverse_ \_ ->
     void $ Ref.modify (_ <> "bar") ref
   AVar.kill (error "Die.") var
-  _ ← AVar.read var case _ of
-    Left err → void $ Ref.modify (_ <> message err) ref
-    Right _  → void $ Ref.modify (_ <> "BAD") ref
+  _ <- AVar.read var case _ of
+    Left err -> void $ Ref.modify (_ <> message err) ref
+    Right _ -> void $ Ref.modify (_ <> "BAD") ref
   eq "barDie." <$> Ref.read ref
 
-test_kill_empty ∷ Effect Unit
+test_kill_empty :: Effect Unit
 test_kill_empty = test "kill/empty" do
-  ref ← Ref.new ""
-  var ← AVar.empty
+  ref <- Ref.new ""
+  var <- AVar.empty
   AVar.kill (error "Die.") var
-  _ ← AVar.read var case _ of
-    Left err → void $ Ref.modify (_ <> message err) ref
-    Right _  → void $ Ref.modify (_ <> "BAD") ref
+  _ <- AVar.read var case _ of
+    Left err -> void $ Ref.modify (_ <> message err) ref
+    Right _ -> void $ Ref.modify (_ <> "BAD") ref
   eq "Die." <$> Ref.read ref
 
-test_kill_pending ∷ Effect Unit
+test_kill_pending :: Effect Unit
 test_kill_pending = test "kill/pending" do
-  ref ← Ref.new ""
-  var ← AVar.empty
+  ref <- Ref.new ""
+  var <- AVar.empty
   let
     cb s = case _ of
-      Left err → void $ Ref.modify (_ <> s <> message err) ref
-      Right _  → void $ Ref.modify (_ <> "BAD") ref
-  _ ← AVar.take var (cb "a")
-  _ ← AVar.take var (cb "b")
-  _ ← AVar.read var (cb "c")
-  _ ← AVar.read var (cb "d")
+      Left err -> void $ Ref.modify (_ <> s <> message err) ref
+      Right _ -> void $ Ref.modify (_ <> "BAD") ref
+  _ <- AVar.take var (cb "a")
+  _ <- AVar.take var (cb "b")
+  _ <- AVar.read var (cb "c")
+  _ <- AVar.read var (cb "d")
   AVar.kill (error "-die.") var
   eq "c-die.d-die.a-die.b-die." <$> Ref.read ref
 
-test_cancel ∷ Effect Unit
+test_cancel :: Effect Unit
 test_cancel = test "cancel" do
-  ref ← Ref.new ""
-  v1 ← AVar.new ""
-  c1 ← AVar.put "a" v1 $ traverse_ \_ → void $ Ref.modify (_ <> "a") ref
-  c2 ← AVar.put "b" v1 $ traverse_ \_ → void $ Ref.modify (_ <> "b") ref
-  _ ← AVar.put "c" v1 $ traverse_ \_ → void $ Ref.modify (_ <> "c") ref
+  ref <- Ref.new ""
+  v1 <- AVar.new ""
+  c1 <- AVar.put "a" v1 $ traverse_ \_ -> void $ Ref.modify (_ <> "a") ref
+  c2 <- AVar.put "b" v1 $ traverse_ \_ -> void $ Ref.modify (_ <> "b") ref
+  _ <- AVar.put "c" v1 $ traverse_ \_ -> void $ Ref.modify (_ <> "c") ref
   c1
   c2
-  _  ← AVar.tryTake v1
-  _  ← AVar.tryTake v1
-  _  ← AVar.tryTake v1
-  v2 ← AVar.empty
-  _ ← AVar.take v2 $ traverse_ \_ → void $ Ref.modify (_ <> "d") ref
-  c5 ← AVar.take v2 $ traverse_ \_ → void $ Ref.modify (_ <> "e") ref
-  _ ← AVar.take v2 $ traverse_ \_ → void $ Ref.modify (_ <> "f") ref
+  _ <- AVar.tryTake v1
+  _ <- AVar.tryTake v1
+  _ <- AVar.tryTake v1
+  v2 <- AVar.empty
+  _ <- AVar.take v2 $ traverse_ \_ -> void $ Ref.modify (_ <> "d") ref
+  c5 <- AVar.take v2 $ traverse_ \_ -> void $ Ref.modify (_ <> "e") ref
+  _ <- AVar.take v2 $ traverse_ \_ -> void $ Ref.modify (_ <> "f") ref
   c5
-  _  ← AVar.tryPut "a" v2
-  _  ← AVar.tryPut "b" v2
-  _  ← AVar.tryPut "c" v2
-  v3 ← AVar.empty
-  _ ← AVar.read v3 $ traverse_ \_ → void $ Ref.modify (_ <> "g") ref
-  c8 ← AVar.read v3 $ traverse_ \_ → void $ Ref.modify (_ <> "h") ref
-  c9 ← AVar.read v3 $ traverse_ \_ → void $ Ref.modify (_ <> "i") ref
+  _ <- AVar.tryPut "a" v2
+  _ <- AVar.tryPut "b" v2
+  _ <- AVar.tryPut "c" v2
+  v3 <- AVar.empty
+  _ <- AVar.read v3 $ traverse_ \_ -> void $ Ref.modify (_ <> "g") ref
+  c8 <- AVar.read v3 $ traverse_ \_ -> void $ Ref.modify (_ <> "h") ref
+  c9 <- AVar.read v3 $ traverse_ \_ -> void $ Ref.modify (_ <> "i") ref
   c8
   c9
-  _  ← AVar.tryPut "a" v3
+  _ <- AVar.tryPut "a" v3
   eq "cdfg" <$> Ref.read ref
 
-main ∷ Effect Unit
+main :: Effect Unit
 main = do
   test_tryRead_full
   test_tryRead_empty


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
