### PR TITLE
Relax Aff upper bound

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-aff": "^7.0.0",
+    "purescript-aff": ">=7.0.0 <9.0.0",
     "purescript-effect": "^4.0.0",
     "purescript-either": "^6.0.0",
     "purescript-exceptions": "^6.0.0",


### PR DESCRIPTION
Currently avar isn't in the package set because Aff had a major version bump.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
